### PR TITLE
Change parent class from StaticChallenge to Attendance

### DIFF
--- a/r8_example/helloworld.py
+++ b/r8_example/helloworld.py
@@ -1,8 +1,8 @@
 import r8
-from r8.builtin_challenges.basic import StaticChallenge
+from r8.builtin_challenges.basic import Attendance
 
 
-class HelloWorld(StaticChallenge):
+class HelloWorld(Attendance):
     title = "Hello World"
     flag = "__flag__{test}"
 

--- a/r8_example/helloworld.py
+++ b/r8_example/helloworld.py
@@ -1,8 +1,7 @@
 import r8
-from r8.builtin_challenges.basic import Attendance
 
 
-class HelloWorld(Attendance):
+class HelloWorld(r8.Challenge):
     title = "Hello World"
     flag = "__flag__{test}"
 


### PR DESCRIPTION
Hy Max

Seems that you renamed the class `StaticChallenge` to `Attendance` in the `r8` package. Thus, the tutorial on how to install `r8-example` runs into an error when calling `r8 challenges list-available`.

Greez
R